### PR TITLE
change to yt-dlp

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,30 +1,31 @@
 name: Python package
 
-on: [pull_request]
+on:
+  pull_request:
+    branches: [ $default-branch ]
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
+      fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flit
+        pip install flit flake8
         flit install -s
     - name: Lint with flake8
       run: |
-        pip install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,9 +7,9 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 3
+      max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v1

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# vscode
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # totalsize
-Script that uses youtube-dl to calculate total size of all videos in a playlist (also works with single videos).
+Script that uses yt-dlp to calculate total size of all videos in a playlist (also works with single videos).
 # Installation
 
 ```
@@ -14,7 +14,7 @@ totalsize [-h] [-f FORMAT_FILTER] [-m] [-r NUM] [-c FILE] [--media]
           [--percentage] [--cookies FILE]
           URL
 ```
-See https://github.com/ytdl-org/youtube-dl#format-selection for details on formats.
+See https://github.com/yt-dlp/yt-dlp#format-selection for details on formats.
 
 Specify the `-m` option for additional info on each video.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
 [build-system]
-requires = ["flit_core >=2,<3"]
+requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
-[tool.flit.metadata]
-module = "totalsize"
-author = "theychx"
-author-email = "theychx@fastmail.com"
-home-page = "https://github.com/theychx/totalsize"
-requires = ["youtube-dl >=2019.11.22"]
+[project]
+name = "totalsize"
+authors = [{name = "theychx", email = "theychx@fastmail.com"}]
+readme = "README.md"
+license = {file = "LICENSE"}
+dynamic = ["version", "description"]
+dependencies = ["yt-dlp >=2022.5.18"]
 requires-python = ">=3.6"
 classifiers = [
     "License :: OSI Approved :: MIT License",
@@ -16,11 +17,15 @@ classifiers = [
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Multimedia",
     "Topic :: Multimedia :: Sound/Audio",
     "Topic :: Multimedia :: Video",
 ]
 
+[project.urls]
+Home = "https://github.com/theychx/totalsize"
 
-[tool.flit.scripts]
+[project.scripts]
 totalsize = "totalsize.total:cli"

--- a/tests/test_totalsize.py
+++ b/tests/test_totalsize.py
@@ -8,9 +8,9 @@ class TestTotal(unittest.TestCase):
     def test_get_totalsize_yt_channel(self):
         playlist = Playlist("https://www.youtube.com/channel/UCvAUb8YbRyXz_l9CXptKoQA/", "18")
         playlist.accum_info()
-        self.assertEqual(playlist.totals.size, 425674114)
+        self.assertEqual(playlist.totals.size, 430723724)
         self.assertEqual(playlist.number_of_media, 4)
-        self.assertEqual(playlist.number_of_media_inacc, 0)
+        self.assertEqual(playlist.number_of_media_inacc, 1)
         self.assertEqual(playlist.number_of_media_nosize, 0)
 
     def test_get_totalsize_yt_playlist(self):
@@ -18,9 +18,9 @@ class TestTotal(unittest.TestCase):
             "https://www.youtube.com/watch?v=KIHBpp34JkA&list=PLGx22rG4Cm6dEFvkjmdSRpulz6l0M-g2u", "18"
         )
         playlist.accum_info()
-        self.assertEqual(playlist.totals.size, 197941592)
+        self.assertEqual(playlist.totals.size, 202991202)
         self.assertEqual(playlist.number_of_media, 3)
-        self.assertEqual(playlist.number_of_media_inacc, 0)
+        self.assertEqual(playlist.number_of_media_inacc, 1)
         self.assertEqual(playlist.number_of_media_nosize, 0)
 
     def test_get_totalsize_yt_video(self):
@@ -38,12 +38,6 @@ class TestTotal(unittest.TestCase):
         self.assertEqual(playlist.number_of_media, 11)
         self.assertEqual(playlist.number_of_media_inacc, 0)
         self.assertEqual(playlist.number_of_media_nosize, 11)
-
-    def test_get_totalsize_unsupported_url(self):
-        playlist = Playlist("https://google.com", "best")
-        playlist.accum_info()
-        self.assertIsNone(playlist.totals.size)
-        self.assertEqual(playlist.number_of_media, 0)
 
 
 if __name__ == "__main__":

--- a/totalsize/__init__.py
+++ b/totalsize/__init__.py
@@ -1,4 +1,4 @@
-"""Totalsize uses youtube-dl to calculate total size of all videos in a playlist"""
+"""Totalsize uses yt-dlp to calculate total size of all videos in a playlist"""
 
 __author__ = "theychx"
 __email__ = "theychx@fastmail.com"

--- a/totalsize/__init__.py
+++ b/totalsize/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = "theychx"
 __email__ = "theychx@fastmail.com"
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/totalsize/total.py
+++ b/totalsize/total.py
@@ -9,11 +9,11 @@ import tempfile
 import time
 from pathlib import Path
 
-import youtube_dl
-from youtube_dl.utils import DownloadError, ExtractorError
+import yt_dlp
+from yt_dlp.utils import DownloadError, ExtractorError
 
-DEFAULT_FORMAT = "bestvideo+bestaudio/best"
-FORMAT_DOC_URL = "https://github.com/ytdl-org/youtube-dl#format-selection"
+DEFAULT_FORMAT = "bestvideo*+bestaudio/best"
+FORMAT_DOC_URL = "https://github.com/yt-dlp/yt-dlp#format-selection"
 FRAGMENTS_REGEX = re.compile(r"range/[\d]+-([\d]+)$")
 TEMPPATH = Path(tempfile.gettempdir(), "totalsize", "fragment")
 TIMEOUT = 30
@@ -153,7 +153,7 @@ class Playlist:
         if cookies_path:
             opts["cookiefile"] = str(cookies_path)
         self._retries = retries
-        self._ydl = youtube_dl.YoutubeDL(opts)
+        self._ydl = yt_dlp.YoutubeDL(opts)
         TEMPPATH.parent.mkdir(exist_ok=True)
 
         try:


### PR DESCRIPTION
This commit changes to [yt-dlp](https://github.com/yt-dlp/yt-dlp), since the original youtube-dl has seen very little active development in the past year or so, leaving it partially or completely broken on many supported sites (including youtube itself). In contrast, yt-dlp seems to have become the de-facto successor, receiving constant updates, nearly daily commits, and many new features/supported sites that will likely never be merged back into youtube-dl.

It does appear that as of a few days ago the original youtube-dl gained a new leader who will be backporting some of the important stuff from yt-dlp, however it seems that the changes are too big to backport everything, and they still intend to maintain python2 and command option compatibility, meaning that yt-dlp will likely still remain the place for development and features/fixes.

ytdl-org/youtube-dl#30568

I did some limited testing and things still seem to work as expected. However, the included test file returns an assertion error on the size, presumably due to yt-dlp using a new default sort order.

Also, thanks a lot for making this tool! I've found it very useful on many occasions :)